### PR TITLE
fix: TogetherAI add output type to getResponseFormat()

### DIFF
--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -21,7 +21,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         });
     }
 
-    getResponseFormat = (options: ExecutionOptions) => {
+    getResponseFormat = (options: ExecutionOptions): { type: string; schema: any } | undefined => {
         return options.result_schema ?
             {
                 type: "json_object",


### PR DESCRIPTION
Fixes an intermittent typescript build error by adding output type to getResponseFormat() in the TogetherAI driver.