### PR TITLE
feat/37 Add generalised support for canStream, to support AWS cross-region inference

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -413,7 +413,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         }
         if (error) {
-            console.warn("Error on canStream check for model " + model, error);
+            console.warn("Error on canStream check for model: " + model + " region detected: " + region, error);
         }
         return canStream;
     }

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -387,7 +387,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
         
         if (error) {
-            throw error;
+            console.warn("Error on canStream check for model " + model, error);
         }
         return canStream;
     }

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -112,16 +112,13 @@ if (process.env.BEDROCK_REGION) {
         driver: new BedrockDriver({
             region: process.env.BEDROCK_REGION as string,
         }),
+        //Use foundation models and inference profiles to test the driver
         models: [
             "anthropic.claude-3-sonnet-20240229-v1:0",
-            "anthropic.claude-v2:1",
-            //"cohere.command-text-v14", EOL
             "mistral.mixtral-8x7b-instruct-v0:1",
             "cohere.command-r-plus-v1:0",
-            "meta.llama3-1-70b-instruct-v1:0",
+            "us.meta.llama3-1-70b-instruct-v1:0",
             "us.amazon.nova-micro-v1:0",
-            //"us.amazon.nova-lite-v1:0",
-            //"us.amazon.nova-pro-v1:0",
         ]
     }
     )


### PR DESCRIPTION
Add generalised support for canStream, to support AWS cross-region inference

* https://github.com/becomposable/llumiverse/issues/37


AWS inference support is mostly automatic if the underlying model is supported. We were getting errors from the canStream function which used `getFoundationModel()` to check if the model string provided (which could be a model or inference profile) supports streaming.
This returned a error for inference profiles as you have to use `getInferenceProfile()` instead, and then `getFoundationModel()` on the underlying model. Similar was done for custom models.

The implementation only checks the first model in the inference profile. It is assumed all models have the same level of streaming support. For cross-region inference the models in the list should be the same, just on different servers, so this assumption is safe.

This replaces the temporary hack used for Amazon Nova support.

Dev validation:
Try some cross-region inference profiles. They appear in the model list in studio with a location prefix
i.e. US Amazon Nova Pro