### PR TITLE
feat35/ Add Image support to Amazon Nova

### DIFF
--- a/core/src/formatters/nova.ts
+++ b/core/src/formatters/nova.ts
@@ -1,5 +1,5 @@
 import { JSONSchema4 } from "json-schema";
-import { PromptRole, PromptSegment } from "../index.js";
+import { PromptRole, PromptSegment, readStreamAsBase64 } from "../index.js";
 //import { readStreamAsBase64 } from "../stream.js";
 import { getJSONSafetyNotice } from "./commons.js";
 
@@ -13,16 +13,11 @@ export interface NovaSystemMessage{
 }
 
 interface NovaMessagePart {
-    source?: {
-        type: "base64",
-        media_type: string,
-        data: string,
-    }, // only set for images
     text?: string // only set for text messages
     image?: {
         format: "jpeg" | "png" | "gif" | "webp",
         source: {
-            bytes: "base64",
+            bytes: string //"base64",
         }
     }
     video?: {
@@ -34,7 +29,7 @@ interface NovaMessagePart {
                 bucketOwner: string // optional. example: "123456789012"
             }
             //Option 2: sending a base64 encoded video
-            bytes?: "base64",
+            bytes?: string //"base64",
         }
     }
 }
@@ -56,7 +51,6 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
     for (const segment of segments) {
 
         const parts: NovaMessagePart[] = [];
-        /*
         if (segment.files) for (const f of segment.files) {
             //TODO type: 'image' -> detect from f.mime_type
             //TODO: image and video support
@@ -64,9 +58,14 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
             const source = await f.getStream();
             const data = await readStreamAsBase64(source);
             parts.push({
+                image: {
+                    format: 'png',
+                    source: {
+                        bytes: data
+                    }
+                }
             })
         }
-        */
 
         if (segment.content) {
             parts.push({

--- a/core/src/formatters/nova.ts
+++ b/core/src/formatters/nova.ts
@@ -52,8 +52,7 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
 
         const parts: NovaMessagePart[] = [];
         if (segment.files) for (const f of segment.files) {
-            //TODO type: 'image' -> detect from f.mime_type
-            //TODO: image and video support
+            //TODO add video support
             if (!f.mime_type?.startsWith('image')) {
                 continue;
             }

--- a/core/src/formatters/nova.ts
+++ b/core/src/formatters/nova.ts
@@ -54,12 +54,17 @@ export async function formatNovaPrompt(segments: PromptSegment[], schema?: JSONS
         if (segment.files) for (const f of segment.files) {
             //TODO type: 'image' -> detect from f.mime_type
             //TODO: image and video support
+            if (!f.mime_type?.startsWith('image')) {
+                continue;
+            }
 
             const source = await f.getStream();
             const data = await readStreamAsBase64(source);
+            const format = f.mime_type?.split('/')[1] || 'png';
+            
             parts.push({
                 image: {
-                    format: 'png',
+                    format: format as "jpeg" | "png" | "gif" | "webp",
                     source: {
                         bytes: data
                     }


### PR DESCRIPTION
Adds image support for inputs to Amazona Nova

* https://github.com/becomposable/llumiverse/issues/35

Supported file types are "jpeg" | "png" | "gif" | "webp"