### PR TITLE
Feat48 - Gemini 1.5 version 002 models

### DIFF
--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -31,8 +31,37 @@ export function getAIModels() {
     return Object.values(Models).map(m => m.model);
 }
 
+// Must be updated when adding new models
+const Models: Record<string, ModelDefinition> = {
+    "gemini-1.5-flash-002": new GeminiModelDefinition("gemini-1.5-flash-002"),
+    "gemini-1.5-flash-001": new GeminiModelDefinition("gemini-1.5-flash-001"),
+    "gemini-1.5-flash": new GeminiModelDefinition("gemini-1.5-flash"),
+    "gemini-1.5-pro-002": new GeminiModelDefinition("gemini-1.5-pro-002"),
+    "gemini-1.5-pro-001": new GeminiModelDefinition("gemini-1.5-pro-001"),
+    "gemini-1.5-pro": new GeminiModelDefinition("gemini-1.5-pro"),
+    "gemini-1.0-pro": new GeminiModelDefinition(),
+}
+
 // Builtin models. VertexAI doesn't provide an API to list models. so we have to hardcode them here.
 export const BuiltinModels: AIModel<string>[] = [
+    {
+        id: "gemini-1.5-flash-001",
+        name: "Gemini Pro 1.5 Flash 001",
+        provider: "vertexai",
+        owner: "google",
+        type: ModelType.MultiModal,
+        can_stream: true,
+        is_multimodal: true
+    },
+    {
+        id: "gemini-1.5-flash-002",
+        name: "Gemini Pro 1.5 Flash 002",
+        provider: "vertexai",
+        owner: "google",
+        type: ModelType.MultiModal,
+        can_stream: true,
+        is_multimodal: true
+    },
     {
         id: "gemini-1.5-flash",
         name: "Gemini Pro 1.5 Flash",
@@ -41,7 +70,24 @@ export const BuiltinModels: AIModel<string>[] = [
         type: ModelType.MultiModal,
         can_stream: true,
         is_multimodal: true
-
+    },
+    {
+        id: "gemini-1.5-pro-001",
+        name: "Gemini Pro 1.5 Pro 001",
+        provider: "vertexai",
+        owner: "google",
+        type: ModelType.MultiModal,
+        can_stream: true,
+        is_multimodal: true
+    },
+    {
+        id: "gemini-1.5-pro-002",
+        name: "Gemini Pro 1.5 Pro 002",
+        provider: "vertexai",
+        owner: "google",
+        type: ModelType.MultiModal,
+        can_stream: true,
+        is_multimodal: true
     },
     {
         id: "gemini-1.5-pro",
@@ -51,7 +97,6 @@ export const BuiltinModels: AIModel<string>[] = [
         type: ModelType.MultiModal,
         can_stream: true,
         is_multimodal: true
-
     },
     {
         id: "gemini-1.0-pro",
@@ -61,29 +106,4 @@ export const BuiltinModels: AIModel<string>[] = [
         type: ModelType.Text,
         can_stream: true,
     },
-    {
-        id: "tablextembedding-gecko",
-        name: "Gecko Text Embeddings",
-        provider: "vertexai",
-        owner: "google",
-        type: ModelType.Embedding,
-    },
-    {
-        id: "textembedding-gecko-multilingual",
-        name: "Gecko Multilingual Text Embeddings",
-        provider: "vertexai",
-        owner: "google",
-        type: ModelType.Embedding,
-    },
-
-
-
 ]
-
-
-
-const Models: Record<string, ModelDefinition> = {
-    "gemini-1.5-flash": new GeminiModelDefinition("gemini-1.5-flash"),
-    "gemini-1.5-pro": new GeminiModelDefinition("gemini-1.5-pro"),
-    "gemini-1.0-pro": new GeminiModelDefinition(),
-}

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -31,17 +31,6 @@ export function getAIModels() {
     return Object.values(Models).map(m => m.model);
 }
 
-// Must be updated when adding new models
-const Models: Record<string, ModelDefinition> = {
-    "gemini-1.5-flash-002": new GeminiModelDefinition("gemini-1.5-flash-002"),
-    "gemini-1.5-flash-001": new GeminiModelDefinition("gemini-1.5-flash-001"),
-    "gemini-1.5-flash": new GeminiModelDefinition("gemini-1.5-flash"),
-    "gemini-1.5-pro-002": new GeminiModelDefinition("gemini-1.5-pro-002"),
-    "gemini-1.5-pro-001": new GeminiModelDefinition("gemini-1.5-pro-001"),
-    "gemini-1.5-pro": new GeminiModelDefinition("gemini-1.5-pro"),
-    "gemini-1.0-pro": new GeminiModelDefinition(),
-}
-
 // Builtin models. VertexAI doesn't provide an API to list models. so we have to hardcode them here.
 export const BuiltinModels: AIModel<string>[] = [
     {
@@ -107,3 +96,14 @@ export const BuiltinModels: AIModel<string>[] = [
         can_stream: true,
     },
 ]
+
+// Must be updated when adding new models
+const Models: Record<string, ModelDefinition> = {
+    "gemini-1.5-flash-002": new GeminiModelDefinition("gemini-1.5-flash-002"),
+    "gemini-1.5-flash-001": new GeminiModelDefinition("gemini-1.5-flash-001"),
+    "gemini-1.5-flash": new GeminiModelDefinition("gemini-1.5-flash"),
+    "gemini-1.5-pro-002": new GeminiModelDefinition("gemini-1.5-pro-002"),
+    "gemini-1.5-pro-001": new GeminiModelDefinition("gemini-1.5-pro-001"),
+    "gemini-1.5-pro": new GeminiModelDefinition("gemini-1.5-pro"),
+    "gemini-1.0-pro": new GeminiModelDefinition(),
+}


### PR DESCRIPTION
* https://github.com/becomposable/llumiverse/issues/48

Exposes the Gemini 1.5 002 version models, i.e. gemini-1.5-pro-002.

Also exposes the 001 versions similarly.

As a clean up, the embedding models are removed from the list. This does not make them inaccessible for embedding, it just mean you cannot use them for normal requests, which is correct.

AIModel listing names for 001 and 002 model version may change in future.