### PR TITLE
Fix: change vitest bedrock region to us-east-1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,6 +61,6 @@ jobs:
         MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-        BEDROCK_REGION: us-west-2
+        BEDROCK_REGION: us-east-1
 
 


### PR DESCRIPTION
Amazon Nova Canvas only exists on us-east-1, changing region to us-east-1 from us-west-2 for the vitest tests.